### PR TITLE
fix: overwrite stroke

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -134,7 +134,9 @@ async function processIcon(file: string, symbolId: string, options: Required<Opt
     }
   }
   // fix cannot change svg color  by  parent node problem
-  svg = svg.replace(/stroke="[a-zA-Z#0-9]*"/, 'stroke="currentColor"')
+  if (options.reWriteStroke) {
+    svg = svg.replace(/stroke="[^"]*"/g, 'stroke="currentColor"')
+  }
   return convertSvgToSymbol(symbolId, svg)
 }
 
@@ -171,6 +173,7 @@ function mergeOptions(userOptions: Options): Required<Options> {
     svgoOptions: {},
     inject: 'body-last',
     customDomId: SVG_DOM_ID,
+    reWriteStroke: true,
     ...userOptions,
   }
 }

--- a/packages/core/src/typing.ts
+++ b/packages/core/src/typing.ts
@@ -31,6 +31,11 @@ export interface Options {
    * default: '__svg__icons__dom__'
    */
   customDomId?: string
+  /**
+   * Override all strokes in svg as currentColor
+   * @default: true
+   */
+  reWriteStroke?: boolean
 }
 
 export type SymbolEntry = {


### PR DESCRIPTION
Fixed bug where only the first stroke was overwritten. Added config option to control overwriting.
修复了仅覆写第一个stroke的bug，新增是否覆写的配置项